### PR TITLE
fix(boxplot): correct min, max, outlier values

### DIFF
--- a/src/js/display.js
+++ b/src/js/display.js
@@ -455,7 +455,7 @@ class Display {
         textTerse += ' ';
       }
       // val
-      if (plot.plotData[plotPos][sectionKey] != null && !isOutlier) {
+      if (plot.plotData[plotPos][sectionKey] == null && !isOutlier) {
         textTerse += 'empty';
         textVerbose += 'empty';
       } else {


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of the changes made in this pull request. -->
Since the empty values were displayed when the values were present, the text mode showed the min, max, and outlier values as empty. This PR corrects this bug.

## Related Issues
<!-- Specify any related issues or tickets that this pull request addresses. -->

## Changes Made
<!-- Describe the specific changes made in this pull request. -->
Changed the text mode to display empty values, when the values are null

## Screenshots (if applicable)
<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes
<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
